### PR TITLE
correct spec for de-compress.

### DIFF
--- a/src/zstd.erl
+++ b/src/zstd.erl
@@ -16,7 +16,7 @@ compress(Binary) ->
 compress(_, _) ->
     erlang:nif_error(?LINE).
 
--spec decompress(Compressed :: binary()) -> Uncompressed :: binary().
+-spec decompress(Compressed :: binary()) -> Uncompressed :: binary() | error.
 decompress(_) ->
     erlang:nif_error(?LINE).
 


### PR DESCRIPTION
zstd:decompress/1 can return a `binary()`, or `error` (in the case of invalid data), the spec defines only binary() at this point meaning dialyzer will complain when matching against the error case.

This change adds the error case to the decompress spec making it compliant with the implementation.