### PR TITLE
Accept IoData as compress input

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -33,7 +33,7 @@ endif
 CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I ../priv/zstd/lib
 CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 
-LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei
+LDLIBS += -L $(ERL_INTERFACE_LIB_DIR)
 LDFLAGS += -shared $(CURDIR)/../priv/zstd/lib/libzstd.a
 
 # Verbosity.

--- a/c_src/zstd_nif.c
+++ b/c_src/zstd_nif.c
@@ -42,7 +42,7 @@ static ERL_NIF_TERM zstd_nif_decompress(ErlNifEnv* env, int argc, const ERL_NIF_
   outp = enif_make_new_binary(env, uncompressed_size, &out);
 
   if(ZSTD_decompress(outp, uncompressed_size, bin.data, bin.size) != uncompressed_size)
-    return enif_make_atom(env, "error");
+    return enif_make_badarg(env);
 
   return out;
 }

--- a/c_src/zstd_nif.c
+++ b/c_src/zstd_nif.c
@@ -17,7 +17,7 @@ static ERL_NIF_TERM zstd_nif_compress(ErlNifEnv* env, int argc, const ERL_NIF_TE
 
   if(!enif_alloc_binary(buff_size, &ret_bin))
     return enif_make_atom(env, "error");
-  
+
   compressed_size = ZSTD_compress(ret_bin.data, buff_size, bin.data, bin.size, compression_level);
   if(ZSTD_isError(compressed_size))
     return enif_make_atom(env, "error");
@@ -40,7 +40,7 @@ static ERL_NIF_TERM zstd_nif_decompress(ErlNifEnv* env, int argc, const ERL_NIF_
   uncompressed_size = ZSTD_getDecompressedSize(bin.data, bin.size);
 
   outp = enif_make_new_binary(env, uncompressed_size, &out);
-  
+
   if(ZSTD_decompress(outp, uncompressed_size, bin.data, bin.size) != uncompressed_size)
     return enif_make_atom(env, "error");
 
@@ -48,7 +48,7 @@ static ERL_NIF_TERM zstd_nif_decompress(ErlNifEnv* env, int argc, const ERL_NIF_
 }
 
 static ErlNifFunc nif_funcs[] = {
-    {"compress", 2, zstd_nif_compress},
+    {"compress_bin", 2, zstd_nif_compress},
     {"decompress", 1, zstd_nif_decompress}
 };
 

--- a/src/zstd.app.src
+++ b/src/zstd.app.src
@@ -1,6 +1,6 @@
 {application,zstd,
              [{description,"Zstd binding for Erlang/Elixir"},
-              {vsn,"0.2.0"},
+              {vsn,"0.3.0"},
               {registered,[]},
               {applications,[kernel,stdlib]},
               {env,[]},

--- a/src/zstd.erl
+++ b/src/zstd.erl
@@ -1,6 +1,6 @@
 -module(zstd).
 
--export([compress/1, compress/2]).
+-export([compress/1, compress/2, compress_bin/2]).
 -export([decompress/1]).
 
 -on_load(init/0).
@@ -8,12 +8,15 @@
 -define(APPNAME, zstd).
 -define(LIBNAME, zstd_nif).
 
--spec compress(Uncompressed :: binary()) -> Compressed :: binary().
-compress(Binary) ->
-    compress(Binary, 1).
+-spec compress(Uncompressed :: iodata()) -> Compressed :: binary().
+compress(IoData) ->
+    compress(IoData, 1).
 
--spec compress(Uncompressed :: binary(), CompressionLevel :: 0..22) -> Compressed :: binary().
-compress(_, _) ->
+-spec compress(Uncompressed :: iodata(), CompressionLevel :: 0..22) -> Compressed :: binary().
+compress(IoData, Level) ->
+    compress_bin(iolist_to_binary(IoData), Level).
+
+compress_bin(_, _) ->
     erlang:nif_error(?LINE).
 
 -spec decompress(Compressed :: binary()) -> Uncompressed :: binary().

--- a/test/zstd_tests.erl
+++ b/test/zstd_tests.erl
@@ -5,3 +5,8 @@
 zstd_test() ->
   Data = <<"Hello, World!">>,
   ?assertEqual(Data, zstd:decompress(zstd:compress(Data))).
+
+zstd_iodata_test() ->
+  Data = ["Hello", ", World!"],
+  Expected = <<"Hello, World!">>,
+  ?assertEqual(Expected, zstd:decompress(zstd:compress(Data))).

--- a/test/zstd_tests.erl
+++ b/test/zstd_tests.erl
@@ -10,3 +10,6 @@ zstd_iodata_test() ->
   Data = ["Hello", ", World!"],
   Expected = <<"Hello, World!">>,
   ?assertEqual(Expected, zstd:decompress(zstd:compress(Data))).
+
+decompression_error_test() ->
+  ?assertError(badarg, zstd:decompress(<<"not valid iodata">>)).


### PR DESCRIPTION
Also removed `-lerl_interface -lei` link option as it's not necessary and no longer supported in OTP 24.